### PR TITLE
changed saveView call to PATCH request, no params needed

### DIFF
--- a/demos/templates/magnet.js
+++ b/demos/templates/magnet.js
@@ -28,6 +28,14 @@ function main ({title, conceptFixture}) {
 					<script class="js-magnet-data" type="application/json">${conceptFixture}</script>
 					<div class="magnet-cta js-magnet-cta"></div>
 				</div>
+				<div class="magnet-filler">
+					^^^^^
+					<br>
+					This is a filler needed to see the IntersectionObserver in action. <br>
+					Scroll up to see the eventpromo above.<br>
+					The "save view" call should only kick in when the eventpromo is in view <br>
+					<br>
+				</div>
 			</div>
 		</body>
 	</html>

--- a/src/components/eventpromo/main.js
+++ b/src/components/eventpromo/main.js
@@ -4,16 +4,14 @@ import xEngine from '@financial-times/x-engine';
 import {getMappedData} from './eventpromo-utils';
 import {dispatchTrackingEvent} from '../../lib/tracking';
 
-async function saveView (viewLink, formattedData) {
+async function saveView (viewLink) {
 	// notify eventpromo-api that this event has been seen
-	const requestBody = {eventpromoId: formattedData.id};
 	await fetch(viewLink, {
-		body: JSON.stringify(requestBody),
 		headers: {
 			accept: 'application/json',
 			'content-type': 'application/json',
 		},
-		method: 'POST',
+		method: 'PATCH',
 	});
 }
 
@@ -40,7 +38,12 @@ export async function renderEventpromo (magnetPlaceholderSelector, data) {
 			const observer = new IntersectionObserver((entries, observer) => {
 				entries.forEach(async function (entry) {
 					if (entry.isIntersecting || entry.intersectionRatio > 0) {
-						await saveView(viewLink, formattedData);
+						try {
+							await saveView(viewLink);
+						}
+						catch (error) {
+							// fail silently
+						}
 						observer.unobserve(entry.target);
 					}
 				});


### PR DESCRIPTION
handle failures on fetch (fire and forget, fail silently)
updated template for better testing of observer
 🐿 v2.12.3