### PR TITLE
use x-engine for JSX instead of direct React

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,3 +1,3 @@
 import { magnetInit } from './src/main';
 
-export { magnetInit } 
+export { magnetInit }; 

--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
     "mini-css-extract-plugin": "^0.4.4",
     "node-sass": "^4.9.4",
     "pa11y-ci": "^2.1.1",
+    "react": "^16.12.0",
+    "react-dom": "^16.12.0",
     "sass-loader": "^7.1.0",
     "snyk": "^1.167.2",
     "webpack": "^4.23.1",
@@ -58,9 +60,7 @@
     "@financial-times/n-eventpromo": "^6.0.0-beta.1",
     "handlebars-loader": "^1.7.0",
     "js-cookie": "^2.2.0",
-    "@financial-times/ft-date-format": "^1.0.0",
-    "react": "^16.5.2",
-    "react-dom": "^16.5.2"
+    "@financial-times/ft-date-format": "^1.0.0"
   },
   "x-dash": {
     "engine": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "webpack-cli": "^3.1.2"
   },
   "dependencies": {
-    "@financial-times/x-engine": "^1.0.0-beta.5",
+    "@financial-times/x-engine": "^1.0.2",
     "@financial-times/n-eventpromo": "^6.0.0-beta.1",
     "handlebars-loader": "^1.7.0",
     "js-cookie": "^2.2.0",

--- a/src/components/eventpromo/main.js
+++ b/src/components/eventpromo/main.js
@@ -1,6 +1,6 @@
-import React from 'react';
+/** @jsx h */
 import {Eventpromo} from '@financial-times/n-eventpromo';
-import xEngine from '@financial-times/x-engine';
+import {h, render} from '@financial-times/x-engine';
 import {getMappedData} from './eventpromo-utils';
 import {dispatchTrackingEvent} from '../../lib/tracking';
 
@@ -20,7 +20,7 @@ export async function renderEventpromo (magnetPlaceholderSelector, data) {
 		const formattedData = getMappedData(data);
 		const promoElement = <Eventpromo isPaused={true} {...formattedData} />;
 		const viewLink = data.viewLink;
-		xEngine.render(promoElement, magnetPlaceholderSelector);
+		render(promoElement, magnetPlaceholderSelector);
 
 		// tracking
 		dispatchTrackingEvent({


### PR DESCRIPTION
using React means this isn't properly compatible with apps using x-engine.

this blocks financial-times/next-article#3587. i can't test it with `npm link`, some babel-runtime resolution problem, so i'll release a beta once this is merged.