### PR TITLE
Bump version of n-eventpromo to 6.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@financial-times/x-engine": "^1.0.2",
-    "@financial-times/n-eventpromo": "^6.0.0",
+    "@financial-times/n-eventpromo": "^6.1.0",
     "handlebars-loader": "^1.7.0",
     "js-cookie": "^2.2.0",
     "@financial-times/ft-date-format": "^1.0.0"


### PR DESCRIPTION
Contains 'Update FT live logo'. Release: https://github.com/Financial-Times/n-eventpromo/releases/tag/v6.1.0