### PR TITLE
feat(HIVE-43): update to use n-eventpromo v7.x

### DIFF
--- a/demos/eventpromoFixture.json
+++ b/demos/eventpromoFixture.json
@@ -15,12 +15,16 @@
     "displayStartTime": "2018-05-15T07:00:00.000Z",
     "eventUrl": "https://live.ft.com/Events/2018/FT-Brexit-and-Beyond-Summit",
     "id": "f17e63fd1eda51789dc5e6bdd8e3dfae",
-    "imageUrl": "https://live.ft.com/var/ftlive/storage/images/events/2018/ft-brexit-and-beyond-summit/888258-7-eng-GB/FT-Brexit-and-Beyond-Summit.png",
+    "imageUrl": "https://res.cloudinary.com/bizzaboprod/image/upload/q_auto:best,c_crop,g_custom/v1612185684/job3hld3wdyvh60jo3qk.jpg",
     "lastUpdate": "1525098575",
     "scheduledEndTime": "2018-11-14T18:00:00.000Z",
     "scheduledStartTime": "2018-11-12T07:00:00.000Z",
     "score": 0,
-    "sectorTags": ["Boris", "May", "Junker"],
+    "sectorTags": [
+      "Boris",
+      "May",
+      "Junker"
+    ],
     "segmentId": "11259aab-28bd-cf0b-29c5-d6cde7eeac80",
     "strapline": "Planning for Post-Brexit Growth",
     "title": "FT Brexit and Beyond Summit",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@financial-times/x-engine": "^1.0.2",
-    "@financial-times/n-eventpromo": "^6.1.0",
+    "@financial-times/n-eventpromo": "^7.0.0",
     "handlebars-loader": "^1.7.0",
     "js-cookie": "^2.2.0",
     "@financial-times/ft-date-format": "^1.0.0"

--- a/src/components/eventpromo/eventpromo-utils.js
+++ b/src/components/eventpromo/eventpromo-utils.js
@@ -14,14 +14,11 @@ export function getFormattedDate (theEvent) {
 
 export function getMappedData (theEvent) {
 	const eventUrl = new URL(theEvent.eventUrl);
-	const images = [theEvent.imageUrl, ...config.get('eventpromoAnimationStaticImages')];
-
 	eventUrl.searchParams.set('segmentId', theEvent.segmentId);
-
 	return {
 		dates: getFormattedDate(theEvent),
 		id: theEvent.id,
-		images,
+		imageUrl: theEvent.imageUrl || config.get('eventpromoDefaultImage'),
 		link: eventUrl.toString(),
 		location: theEvent.location,
 		segmentId: theEvent.segmentId,

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -1,9 +1,4 @@
-const staticAssetsBasePath = 'https://www.ft.com/__assets/creatives/better-promo';
-
 export default {
-	'eventpromoAnimationStaticImages': [
-		`${staticAssetsBasePath}/break_out.jpg`,
-		`${staticAssetsBasePath}/audiance_clapping.jpg`
-	],
+	'eventpromoDefaultImage': 'https://www.ft.com/__assets/creatives/better-promo/audiance_clapping.jpg',
 	'magnetDataSourceUrl': '/magnet/api'
 };


### PR DESCRIPTION
# feat(HIVE-43): update to use n-eventpromo v7.x

## What
- updates repo to use n-eventpromo v7.0.0
- update data mapping to account for breaking changes in how images are provided in n-eventpromo v7.x
- use the image that would have been 2nd in the previous animation as the default image if an image has not been set.
- replaces demo image for n-eventpromo to working url