### PR TITLE
fix: bump node version in circle config from 8.x -> 12.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,18 +3,13 @@
 
 references:
 
-  container_config_node8: &container_config_node8
+  container_config_node: &container_config_node
     working_directory: ~/project/build
     docker:
-      - image: circleci/node:8-browsers
-
-  container_config_lambda_node8: &container_config_lambda_node8
-    working_directory: ~/project/build
-    docker:
-      - image: lambci/lambda:build-nodejs8.10
+      - image: circleci/node:12-browsers
 
   workspace_root: &workspace_root
-    ~/project
+                    ~/project
 
   attach_workspace: &attach_workspace
     attach_workspace:
@@ -60,7 +55,7 @@ version: 2
 jobs:
 
   build:
-    <<: *container_config_node8
+    <<: *container_config_node
     steps:
       - checkout
       - run:
@@ -90,7 +85,7 @@ jobs:
             - build
 
   test:
-    <<: *container_config_node8
+    <<: *container_config_node
     steps:
       - *attach_workspace
       - run:
@@ -106,7 +101,7 @@ jobs:
           destination: test-results
 
   publish:
-    <<: *container_config_node8
+    <<: *container_config_node
     steps:
       - *attach_workspace
       - run:


### PR DESCRIPTION
Circleci is currently using node 8.x which is now not supported by snyk, meaning [publishing fails.](https://app.circleci.com/pipelines/github/Financial-Times/n-magnet/509/workflows/b1054df5-5169-4724-bba2-5a629243e992/jobs/2042)

This bumps it to use 12.x (the same as next-article).

