### PR TITLE
feat(HIVE-110): add support for on demand events

### DIFF
--- a/demos/app.js
+++ b/demos/app.js
@@ -31,7 +31,8 @@ const eventPromoFixtures = {
 	'ft-forums': require('./fixtures/promos/eventpromo/ft-forums.json'),
 	'ft-bdp:workshop': require('./fixtures/promos/eventpromo/bpd-workshop.json'),
 	'ft-bdp:diploma': require('./fixtures/promos/eventpromo/bpd-diploma.json'),
-	'ft-bdp:masterclass': require('./fixtures/promos/eventpromo/bpd-masterclass.json')
+	'ft-bdp:masterclass': require('./fixtures/promos/eventpromo/bpd-masterclass.json'),
+	'ft-bdp:online-course': require('./fixtures/promos/eventpromo/bpd-online-course.json')
 };
 
 //ignore favicon request for demo

--- a/demos/fixtures/promos/eventpromo/bpd-online-course.json
+++ b/demos/fixtures/promos/eventpromo/bpd-online-course.json
@@ -1,0 +1,16 @@
+{
+  "type": "eventpromo",
+  "data": {
+    "brand": "ft-bdp:online-course",
+    "concepts": [],
+    "description": "An online course looking at the role of the board member, considering board structure, the specific duties and liabilities associated with being a director and the importance of corporate governance.",
+    "eventUrl": "https://bdp.ft.com/Director-Online/The-Role-of-a-Board-Member",
+    "id": "bdp-online-course-the-role-of-a-board-member",
+    "score": 0,
+    "sectorTags": [],
+    "segmentId": "example-segment-id",
+    "strapline": "An online course looking at the role of the board member, considering board structure, the specific duties and liabilities associated with being a director and the importance of corporate governance.",
+    "title": "The Role of a Board Member",
+    "location": "eLearning"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@financial-times/x-engine": "^1.0.2",
-    "@financial-times/n-eventpromo": "^7.0.2",
+    "@financial-times/n-eventpromo": "^7.1.0",
     "handlebars-loader": "^1.7.0",
     "js-cookie": "^2.2.0",
     "@financial-times/ft-date-format": "^1.0.0"

--- a/src/components/eventpromo/eventpromo-utils.js
+++ b/src/components/eventpromo/eventpromo-utils.js
@@ -1,5 +1,4 @@
 import ftDateFormat from '@financial-times/ft-date-format';
-import * as config from '../../lib/config';
 
 export function getFormattedDate(event) {
 	if (!event.scheduledStartTime || !event.scheduledEndTime) return;
@@ -17,14 +16,14 @@ export function getMappedData(event) {
 	const eventUrl = new URL(event.eventUrl);
 	eventUrl.searchParams.set('segmentId', event.segmentId);
 	return {
-		id: event.id,
-		brand: event.brand,
-		title: event.title,
-		strapline: event.strapline,
-		dates: getFormattedDate(event),
-		location: event.location,
-		link: eventUrl.toString(),
-		imageUrl: event.imageUrl || config.get('eventpromoDefaultImage'),
-		segmentId: event.segmentId
-	};
+        id: event.id,
+        brand: event.brand,
+        title: event.title,
+        strapline: event.strapline,
+        dates: getFormattedDate(event),
+        location: event.location,
+        link: eventUrl.toString(),
+        imageUrl: event.imageUrl,
+        segmentId: event.segmentId
+    };
 }

--- a/src/components/eventpromo/eventpromo-utils.js
+++ b/src/components/eventpromo/eventpromo-utils.js
@@ -2,6 +2,7 @@ import ftDateFormat from '@financial-times/ft-date-format';
 import * as config from '../../lib/config';
 
 export function getFormattedDate(event) {
+	if (!event.scheduledStartTime || !event.scheduledEndTime) return;
 	const year = ftDateFormat.format(event.scheduledStartTime, 'yyyy');
 	const eventStart = ftDateFormat.format(event.scheduledStartTime, 'dd MMMM');
 	const eventEnd = ftDateFormat.format(event.scheduledEndTime, 'dd MMMM');

--- a/src/components/eventpromo/eventpromo-utils.js
+++ b/src/components/eventpromo/eventpromo-utils.js
@@ -16,14 +16,14 @@ export function getMappedData(event) {
 	const eventUrl = new URL(event.eventUrl);
 	eventUrl.searchParams.set('segmentId', event.segmentId);
 	return {
-        id: event.id,
-        brand: event.brand,
-        title: event.title,
-        strapline: event.strapline,
-        dates: getFormattedDate(event),
-        location: event.location,
-        link: eventUrl.toString(),
-        imageUrl: event.imageUrl,
-        segmentId: event.segmentId
-    };
+		id: event.id,
+		brand: event.brand,
+		title: event.title,
+		strapline: event.strapline,
+		dates: getFormattedDate(event),
+		location: event.location,
+		link: eventUrl.toString(),
+		imageUrl: event.imageUrl,
+		segmentId: event.segmentId
+	};
 }


### PR DESCRIPTION
# feat(HIVE-110): add support for on demand events

## What
- prevents display of `undefined - undefined` in date slot if dates are not provided in data.
- removes setting of default image for eventpromos (this is done in n-eventpromo itself, so this is just removing duplication).
- bumps n-eventpromo to v7.1.x
- adds ft-bdp-online-course example to demo

## Why
- BDP online courses are 'on-demand', i.e. they don't have fixed start or end dates. Prior to this PR, the eventpromo would show `undefined - undefined` in the date slot if there are no dates in the data.