### PR TITLE
Remove next-webhooks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,7 +154,3 @@ workflows:
           requires:
             - build
           context: next-nightly-build
-
-notify:
-  webhooks:
-    - url: https://ft-next-webhooks.herokuapp.com/circleci2-workflow


### PR DESCRIPTION
[Ticket.](https://financialtimes.atlassian.net/browse/CI-676)

We're removing all instances of `next-webhooks` as it's deprecated.