### PR TITLE
Upgrade to NPM 7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,10 @@ references:
     branches:
       ignore: /.*/
 
-version: 2
+version: 2.1
+
+orbs:
+  node: circleci/node@4.6.0
 
 jobs:
 
@@ -62,12 +65,11 @@ jobs:
           name: Checkout next-ci-shared-helpers
           command: git clone --depth 1 git@github.com:Financial-Times/next-ci-shared-helpers.git .circleci/shared-helpers
       - *restore_npm_cache
+      - node/install-npm:
+          version: "7"
       - run:
           name: Install project dependencies
           command: make install
-      - run:
-          name: shared-helper / npm-install-peer-deps
-          command: .circleci/shared-helpers/helper-npm-install-peer-deps
       - run:
           name: shared-helper / npm-update
           command: .circleci/shared-helpers/helper-npm-update

--- a/Makefile
+++ b/Makefile
@@ -23,11 +23,6 @@ demo-build:
 demo: demo-build
 	node demos/app
 
-a11y: demo-build
-	@node .pa11yci.js
-	@PA11Y=true node demos/app
-	@$(DONE)
-
 check-secret:
 	secret-squirrel init
 

--- a/demos/app.js
+++ b/demos/app.js
@@ -5,10 +5,6 @@ const forumFixture = require('./fixtures/promos/forumpromo.json');
 const magnetTemplate = require('./templates/magnet.js');
 const homeTemplate = require('./templates/home');
 
-const chalk = require('chalk');
-const errorHighlight = chalk.bold.red;
-const highlight = chalk.bold.green;
-
 const demoPort = 5005;
 
 const app = module.exports = express({
@@ -102,23 +98,6 @@ app.post('/eventpromo/api/save-view', (req, res) => {
 	res.send({});
 });
 
-function runPa11yTests() {
-	const spawn = require('child_process').spawn;
-	const pa11y = spawn('pa11y-ci');
-
-	pa11y.stdout.on('data', (data) => {
-		console.log(highlight(`${data}`)); //eslint-disable-line
-	});
-
-	pa11y.stderr.on('data', (error) => {
-		console.log(errorHighlight(`${error}`)); //eslint-disable-line
-	});
-
-	pa11y.on('close', (code) => {
-		process.exit(code);
-	});
-}
-
 app.use(function (req, res, next) {
 	if (!req.route) {
 		/* eslint-disable-next-line no-console */
@@ -131,8 +110,4 @@ app.use(function (req, res, next) {
 	next();
 });
 
-const listen = app.listen(demoPort);
-
-if (process.env.PA11Y === 'true') {
-	listen.then(runPa11yTests);
-}
+app.listen(demoPort);

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "babel-preset-env": "^1.7.0",
     "babel-preset-react": "^6.24.1",
     "bower": "^1.8.8",
-    "chalk": "latest",
     "check-engine": "^1.10.1",
     "css-loader": "^1.0.0",
     "eslint": "^5.12.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "prepush": "make verify -j3",
     "build-dev": "webpack --config webpack.config.js --mode development --env development",
     "build-prod": "webpack --config webpack.config.js --mode production --env production",
-    "prepare": "npx snyk protect || npx snyk protect -d || true"
+    "prepare": "npx snyk protect || npx snyk protect -d || true",
+    "preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine"
   },
   "repository": {
     "type": "git",
@@ -39,6 +40,7 @@
     "babel-preset-react": "^6.24.1",
     "bower": "^1.8.8",
     "chalk": "latest",
+    "check-engine": "^1.10.1",
     "css-loader": "^1.0.0",
     "eslint": "^5.12.1",
     "eslint-plugin-react": "^7.12.4",
@@ -56,16 +58,24 @@
     "webpack-cli": "^3.1.2"
   },
   "dependencies": {
-    "@financial-times/x-engine": "^1.0.2",
+    "@financial-times/ft-date-format": "^1.0.0",
     "@financial-times/n-eventpromo": "^7.1.1",
+    "@financial-times/x-engine": "^1.0.2",
     "handlebars-loader": "^1.7.0",
-    "js-cookie": "^2.2.0",
-    "@financial-times/ft-date-format": "^1.0.0"
+    "js-cookie": "^2.2.0"
   },
   "x-dash": {
     "engine": {
       "server": "react",
       "browser": "react"
     }
+  },
+  "volta": {
+    "node": "12.22.10",
+    "npm": "7.20.2"
+  },
+  "engines": {
+    "node": "12.x",
+    "npm": "7.x || 8.x"
   }
 }


### PR DESCRIPTION
As part of the migration away from bower we are upgrading this component to NPM 7

**Extra notes**

In doing so the way the `chalk` dependency was used caused some issues when trying to run the demos. This was actually an issue even before npm 7 due to the dependency using `latest`.

It turns out `chalk` was only used in some code that was never run to do with pa11y tests so we removed all of this code as its never been used.

Ideally this component would have some pa11y tests to stop it bubbling errors up to its consumer apps (next-article) but for the time being we are not making this any worse than it was already.