### PR TITLE
Upgrade n-eventpromo to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@financial-times/ft-date-format": "^1.0.0",
-    "@financial-times/n-eventpromo": "^7.1.1",
+    "@financial-times/n-eventpromo": "^8.0.0",
     "@financial-times/x-engine": "^1.0.2",
     "handlebars-loader": "^1.7.0",
     "js-cookie": "^2.2.0"


### PR DESCRIPTION
The latest version of n-eventpromo drops support for bower and uses npm instead