### PR TITLE
Fix event promo sass import path

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -1,2 +1,2 @@
-@import 'node_modules/@financial-times/n-eventpromo/dist/Eventpromo';
+@import 'node_modules/@financial-times/n-magnet/node_modules/@financial-times/n-eventpromo/dist/Eventpromo';
 @import '../n-newsletter-signup/main';


### PR DESCRIPTION
Since upgrading event promo this important path has failed when used within consuming apps like next-article.

This has happened because n-eventpromo now installed dependencies as peer dependencies
