### PR TITLE
Fix builds with babel/runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "homepage": "https://github.com/Financial-Times/n-magnet#readme",
   "devDependencies": {
+    "@babel/runtime": "^7.17.9",
     "@financial-times/n-gage": "^3.6.0",
     "@financial-times/n-internal-tool": "^2.2.4",
     "babel-core": "^6.26.3",


### PR DESCRIPTION
Fix builds in v7 by including the babel/runtime dependency which is needed to work alongside @babel/plugin-transform-runtime