### PR TITLE
Replace n-internal-tool with n-express for the demo app

### DIFF
--- a/demos/app.js
+++ b/demos/app.js
@@ -1,4 +1,4 @@
-const express = require('@financial-times/n-internal-tool');
+const express = require('@financial-times/n-express');
 const conceptFixture = require('./fixtures/concept.json');
 const newsletterFixture = require('./fixtures/promos/newsletter.json');
 const forumFixture = require('./fixtures/promos/forumpromo.json');

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
   "homepage": "https://github.com/Financial-Times/n-magnet#readme",
   "devDependencies": {
     "@babel/runtime": "^7.17.9",
+    "@financial-times/n-express": "^23.0.3",
     "@financial-times/n-gage": "^3.6.0",
-    "@financial-times/n-internal-tool": "^2.2.4",
     "babel-core": "^6.26.3",
     "babel-eslint": "^10.0.1",
     "babel-jest": "^23.6.0",


### PR DESCRIPTION
n-internal-tool is deprecated, and also pulls in some quite outdated dependencies which makes analysing it for migrations harder