### PR TITLE
chore(): bump n-newsletter-signup to v10.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@financial-times/dotcom-server-handlebars": "^7.0.0",
         "@financial-times/ft-date-format": "^1.0.0",
         "@financial-times/n-eventpromo": "^10.0.1",
-        "@financial-times/n-newsletter-signup": "^9.2.0",
+        "@financial-times/n-newsletter-signup": "^10.0.0",
         "@financial-times/x-engine": "^1.0.2",
         "handlebars-loader": "^1.7.0",
         "js-cookie": "^2.2.0",
@@ -2656,14 +2656,6 @@
         "npm": "7.x || 8.x"
       }
     },
-    "node_modules/@financial-times/dotcom-server-handlebars/node_modules/dateformat": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
-      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/@financial-times/eslint-config-next": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@financial-times/eslint-config-next/-/eslint-config-next-4.0.0.tgz",
@@ -2895,15 +2887,18 @@
       }
     },
     "node_modules/@financial-times/n-map-content-to-topper": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-map-content-to-topper/-/n-map-content-to-topper-1.6.0.tgz",
-      "integrity": "sha512-7AezWXpfEEZkz21Taw47h9SoM6Ycg7vrKZ3SOVpo1f0vqRbK7VpnvLOTjhTGOkMdPi5z/5kvjN5ag5P4yvpRMg==",
-      "peer": true
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-map-content-to-topper/-/n-map-content-to-topper-3.4.2.tgz",
+      "integrity": "sha512-M4NsJv8xEYSPHFaWUG0Q5LChhY2oQUWx9WMndS4TeEtzuXjr2DmR4wTWI1HSAcclEYcOZBwXdxaZ4KaFbJy3KQ==",
+      "peer": true,
+      "engines": {
+        "node": "16.x"
+      }
     },
     "node_modules/@financial-times/n-myft-ui": {
-      "version": "28.1.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-myft-ui/-/n-myft-ui-28.1.0.tgz",
-      "integrity": "sha512-yNxdCd+tXrV1BxwbP6t0VzgMr2FK15r0x19l2CjxKyL4ss0h0fEHPn2lee3iwanGSCfcYurYWEGOfyn3xLLhkw==",
+      "version": "28.3.3",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-myft-ui/-/n-myft-ui-28.3.3.tgz",
+      "integrity": "sha512-+JLhmbGfOH/o4hHMDw0kdshjGjeWuezrkWm6n8qXRaEKP4jsuT1u9urfIS1zOOLPleGbOZQA2fix6Zl3DnNxjg==",
       "hasInstallScript": true,
       "dependencies": {
         "date-fns": "2.16.1",
@@ -2911,7 +2906,7 @@
         "form-serialize": "^0.7.2",
         "ftdomdelegate": "^4.0.6",
         "js-cookie": "^2.2.1",
-        "next-myft-client": "^10.1.0",
+        "next-myft-client": "^10.3.0",
         "next-session-client": "^4.0.0",
         "superstore-sync": "^2.1.1"
       },
@@ -2934,9 +2929,9 @@
       }
     },
     "node_modules/@financial-times/n-newsletter-signup": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-newsletter-signup/-/n-newsletter-signup-9.2.0.tgz",
-      "integrity": "sha512-tiwua9ZT3HDm0wsuFp/rVv2yex1dIUkpeoo2bwWJ0u9lc52y782Rv/M0uIg2cWqsI6Vn6tKLSnEqadjZcVJkOQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-newsletter-signup/-/n-newsletter-signup-10.0.0.tgz",
+      "integrity": "sha512-/LY0kniuL1OzXMCDSVdc/e77JOzECkOmqWQDvc58SJ3yhO5dngnSj3PBjWEDRCHYIVH5amh2TWuWfOWCtcX6+g==",
       "hasInstallScript": true,
       "dependencies": {
         "@financial-times/dotcom-server-handlebars": "3.0.0",
@@ -2972,24 +2967,16 @@
         "npm": "7.x || 8.x"
       }
     },
-    "node_modules/@financial-times/n-newsletter-signup/node_modules/dateformat": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
-      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/@financial-times/n-notification": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-notification/-/n-notification-8.2.2.tgz",
-      "integrity": "sha512-PJrWD/YW/Hf7xqnoqALMMr/RDTy9fX0CG3k3ZHHyf/ihkrXMmjqZGvjw3tZqIJQhrqaTQ7A3By0heKSRTga8JQ==",
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-notification/-/n-notification-8.2.4.tgz",
+      "integrity": "sha512-QNBpjKai1lvNnh8mAYoYmE0cDaB9h6qILMG/WWh482Q6SQMdoiuFMbxHlICItX8PxBo+i0zyEMhnRIc8hn3QcQ==",
       "peer": true,
       "engines": {
         "npm": "^7 || ^8"
       },
       "peerDependencies": {
-        "@financial-times/o-colors": "^6.1.1",
+        "@financial-times/o-colors": "^6.5.0",
         "@financial-times/o-typography": "^7.0.3"
       }
     },
@@ -3092,9 +3079,9 @@
       }
     },
     "node_modules/@financial-times/o-colors": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-colors/-/o-colors-6.4.2.tgz",
-      "integrity": "sha512-M9I652qnTL6nDARt/3S2cbmJsiM34ag+1kfHtt37xMf2ZsXA/M7c0s+fYO2UWJ308+eWSa1aA8P5Dl13jndmzQ==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-colors/-/o-colors-6.5.1.tgz",
+      "integrity": "sha512-pNa6G3+CdJ1kiVtW1RAoETn5nwGQ/33ddRxgW7dYO5lZC+KU3MTWKO9PxpR9WU34FXvH+WKsFNmEhdUW9/3pqA==",
       "peer": true,
       "engines": {
         "npm": "^7 || ^8"
@@ -3144,10 +3131,14 @@
       }
     },
     "node_modules/@financial-times/o-forms": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-forms/-/o-forms-9.4.0.tgz",
-      "integrity": "sha512-35aUkEhC4La3wABkqB4QNZwctR+UrFyU0SoSFZH3EA9pCxp20x9CYpYdr8E2106ArK0Uab+jJc8snAw5ukew+A==",
+      "version": "9.9.2",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-forms/-/o-forms-9.9.2.tgz",
+      "integrity": "sha512-pv2B5y1/uDkCIipvqRsPqgsqgJdrtRkKVepd3zu6BQ2n8a6NAPWx1X73qIlvFJRF+OUOOKq+HZ/ODr3NrUqABw==",
       "peer": true,
+      "dependencies": {
+        "@types/lodash.uniqueid": "^4.0.7",
+        "lodash.uniqueid": "^4.0.1"
+      },
       "engines": {
         "npm": "^7 || ^8"
       },
@@ -3155,13 +3146,14 @@
         "@financial-times/math": "^1.0.0",
         "@financial-times/o-brand": "^4.1.0",
         "@financial-times/o-buttons": "^7.2.0",
-        "@financial-times/o-colors": "^6.0.1",
+        "@financial-times/o-colors": "^6.5.0",
         "@financial-times/o-grid": "^6.0.0",
         "@financial-times/o-icons": "^7.0.0",
         "@financial-times/o-loading": "^5.0.0",
-        "@financial-times/o-normalise": "^3.2.0",
+        "@financial-times/o-normalise": "^3.3.0",
         "@financial-times/o-spacing": "^3.0.0",
-        "@financial-times/o-typography": "^7.0.1"
+        "@financial-times/o-typography": "^7.0.1",
+        "@financial-times/o-utils": "^2.2.0"
       }
     },
     "node_modules/@financial-times/o-grid": {
@@ -3206,23 +3198,23 @@
       }
     },
     "node_modules/@financial-times/o-loading": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-loading/-/o-loading-5.2.1.tgz",
-      "integrity": "sha512-63wLZuONKI1tygnq3xUxm1zYsLllBFhyQ+0jK2fnPuUTwzgquHZaO9ncdnsjqs1s2WF3rToZK8dpGlPRsjWgBw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-loading/-/o-loading-5.2.2.tgz",
+      "integrity": "sha512-nlYdz9FFNpHCJLYup1xT5JDs7zvF8RY/AoI5TgzJDGj1VN8EgxUXD3p2J3fb4JgqYEKRVR5iTi9zAo7xR7IpMg==",
       "peer": true,
       "engines": {
         "npm": "^7 || ^8"
       },
       "peerDependencies": {
         "@financial-times/o-brand": "^4.1.0",
-        "@financial-times/o-colors": "^6.0.1",
+        "@financial-times/o-colors": "^6.5.0",
         "@financial-times/sass-mq": "^5.0.2"
       }
     },
     "node_modules/@financial-times/o-normalise": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-normalise/-/o-normalise-3.2.2.tgz",
-      "integrity": "sha512-w7eYm2EB4Wf4cY5IJ/B55xst32mFQIW41f+HZpfykJEvI0ohBM2ghfaLu+JpJdaAv8kRaV8245FdDcngDst3wA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-normalise/-/o-normalise-3.3.1.tgz",
+      "integrity": "sha512-ha33JQBrquklTYb+swGV7FsNfFzP4eDfl2PscV5PruC8fjKkXZWtXuiSXU3m1xIU8+qTb4UjR0q2WEG3fUluhw==",
       "peer": true,
       "engines": {
         "npm": "^7 || ^8"
@@ -3233,9 +3225,9 @@
       }
     },
     "node_modules/@financial-times/o-overlay": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-overlay/-/o-overlay-4.2.4.tgz",
-      "integrity": "sha512-4n4Bp7UqJYjmZTW5gzPnxvyU1pIB5+eK2FUimtxCgcDAt19b6u6zuFaZp3kumLyGNj5Q+qT0GIotLTAaKEVciA==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-overlay/-/o-overlay-4.2.8.tgz",
+      "integrity": "sha512-W9FHsCmLtYXAeMIYDKuE3WQ/5g0wId/6pXgby1j3Yl5q6MUax9SBNgLZ7+AVwN3RpkZRh2O8eTq4cbRI4Iy8Fg==",
       "peer": true,
       "dependencies": {
         "focusable": "^2.3.0",
@@ -3246,9 +3238,9 @@
       },
       "peerDependencies": {
         "@financial-times/o-brand": "^4.1.0",
-        "@financial-times/o-colors": "^6.0.1",
+        "@financial-times/o-colors": "^6.5.0",
         "@financial-times/o-icons": "^7.0.0",
-        "@financial-times/o-normalise": "^3.2.0",
+        "@financial-times/o-normalise": "^3.3.0",
         "@financial-times/o-spacing": "^3.0.0",
         "@financial-times/o-typography": "^7.0.1",
         "@financial-times/o-viewport": "^5.0.0",
@@ -3268,9 +3260,9 @@
       }
     },
     "node_modules/@financial-times/o-tooltip": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-tooltip/-/o-tooltip-5.2.4.tgz",
-      "integrity": "sha512-GXC320/zwTNvacG4PCHSwGBPb+3eWMw7pePUAw41iJ70Wjwy+H9aGbbQikWOiBCiSb6BohwImWOJ6RR0g1dReg==",
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-tooltip/-/o-tooltip-5.2.6.tgz",
+      "integrity": "sha512-9qPtucThIi0k9d17i9AQdw36WvFPqeypq9Ajdmki0+43TRK884Ap9LSFoj5nxT5NVR2BpDm+HghrHLYF5iRPLA==",
       "peer": true,
       "dependencies": {
         "ftdomdelegate": "^4.0.6"
@@ -3290,15 +3282,17 @@
       }
     },
     "node_modules/@financial-times/o-topper": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-topper/-/o-topper-5.2.3.tgz",
-      "integrity": "sha512-4CoeEp5nG7ecmZuJMr7DlEs0w5mPS3jikHxOlVZqMP18qWlwXC6BgbPz1ZslxBt/+SnJmHlNN2VIQevPQLNtEQ==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-topper/-/o-topper-5.8.0.tgz",
+      "integrity": "sha512-CDmgoU+91ved0G9883akDDnFUaQyjM/3lpX4Hq8TTDT4wOS2mwxXXP5F9NvhSER9oXb3brmJp8w5tdi3RdyWhw==",
       "peer": true,
+      "dependencies": {
+        "@financial-times/n-map-content-to-topper": "^3.2.0"
+      },
       "engines": {
         "npm": "^7 || ^8"
       },
       "peerDependencies": {
-        "@financial-times/n-map-content-to-topper": "^1.5.0",
         "@financial-times/o-colors": "^6.0.1",
         "@financial-times/o-editorial-typography": "^2.0.1",
         "@financial-times/o-grid": "^6.0.0",
@@ -3329,9 +3323,9 @@
       }
     },
     "node_modules/@financial-times/o-utils": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-utils/-/o-utils-2.1.1.tgz",
-      "integrity": "sha512-kZQfGjVI0A8axO3aPs8AIGStxG+jGX0FKZgjBTQAx+4Dud6vloVGJpSix+/Q7ym5rewjhDLsFVECM18Lvswbhw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-utils/-/o-utils-2.2.0.tgz",
+      "integrity": "sha512-fCm8428H6GOpNhpwNXDKCe5Gx9GPyrwgFg26UsAfVCVmyjOMFCp2TxJECP6Y+NaXJqx6ZYU4lhARxSiL2HO+5A==",
       "peer": true,
       "engines": {
         "npm": "^7 || ^8"
@@ -4912,6 +4906,21 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.194",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.194.tgz",
+      "integrity": "sha512-r22s9tAS7imvBt2lyHC9B8AGwWnXaYb1tY09oyLkXDs4vArpYJzw09nj8MLx5VfciBPGIb+ZwG0ssYnEPJxn/g==",
+      "peer": true
+    },
+    "node_modules/@types/lodash.uniqueid": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.uniqueid/-/lodash.uniqueid-4.0.7.tgz",
+      "integrity": "sha512-ipMGW5nR+DTR6U5O08k1Ufr1F9iH+F3p7bhdwsnq6V6nCn/HgMq22UalDq4n91+03+pHFKyeXV1Y7vdJrm7S4g==",
+      "peer": true,
+      "dependencies": {
+        "@types/lodash": "*"
+      }
     },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
@@ -8237,6 +8246,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/date-fns"
+      }
+    },
+    "node_modules/dateformat": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/debounce": {
@@ -17248,6 +17265,12 @@
       "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
       "dev": true
     },
+    "node_modules/lodash.uniqueid": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.uniqueid/-/lodash.uniqueid-4.0.1.tgz",
+      "integrity": "sha512-GQQWaIeGlL6DIIr06kj1j6sSmBxyNMwI8kaX9aKpHR/XsMTiaXDVPNPAkiboOTK9OJpTJF/dXT3xYoFQnj386Q==",
+      "peer": true
+    },
     "node_modules/log-update": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
@@ -18240,9 +18263,9 @@
       }
     },
     "node_modules/next-myft-client": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/next-myft-client/-/next-myft-client-10.2.0.tgz",
-      "integrity": "sha512-tmCn7kleYGgSd+0kEhwUketVhm0c0Ci87yFODaGPESK7AT+RmTxdC9QA4oSl8Q9izAJz4dPAgC07fPcz2nr2aw==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/next-myft-client/-/next-myft-client-10.5.0.tgz",
+      "integrity": "sha512-IQqMJpc3wSzdkk2YOqPl6sJApcWzmOWBliNMZJLcSzgSqKEKVt0YCuQrpuRqKFGkqpduvZ47BL1g7lwXlUjD6g==",
       "hasInstallScript": true,
       "dependencies": {
         "black-hole-stream": "0.0.1",
@@ -27222,13 +27245,6 @@
         "mixin-deep": "^2.0.0",
         "react": "^16.12.0",
         "react-dom": "^16.12.0"
-      },
-      "dependencies": {
-        "dateformat": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
-          "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
-        }
       }
     },
     "@financial-times/eslint-config-next": {
@@ -27401,30 +27417,30 @@
       }
     },
     "@financial-times/n-map-content-to-topper": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-map-content-to-topper/-/n-map-content-to-topper-1.6.0.tgz",
-      "integrity": "sha512-7AezWXpfEEZkz21Taw47h9SoM6Ycg7vrKZ3SOVpo1f0vqRbK7VpnvLOTjhTGOkMdPi5z/5kvjN5ag5P4yvpRMg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-map-content-to-topper/-/n-map-content-to-topper-3.4.2.tgz",
+      "integrity": "sha512-M4NsJv8xEYSPHFaWUG0Q5LChhY2oQUWx9WMndS4TeEtzuXjr2DmR4wTWI1HSAcclEYcOZBwXdxaZ4KaFbJy3KQ==",
       "peer": true
     },
     "@financial-times/n-myft-ui": {
-      "version": "28.1.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-myft-ui/-/n-myft-ui-28.1.0.tgz",
-      "integrity": "sha512-yNxdCd+tXrV1BxwbP6t0VzgMr2FK15r0x19l2CjxKyL4ss0h0fEHPn2lee3iwanGSCfcYurYWEGOfyn3xLLhkw==",
+      "version": "28.3.3",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-myft-ui/-/n-myft-ui-28.3.3.tgz",
+      "integrity": "sha512-+JLhmbGfOH/o4hHMDw0kdshjGjeWuezrkWm6n8qXRaEKP4jsuT1u9urfIS1zOOLPleGbOZQA2fix6Zl3DnNxjg==",
       "requires": {
         "date-fns": "2.16.1",
         "fetchres": "^1.7.2",
         "form-serialize": "^0.7.2",
         "ftdomdelegate": "^4.0.6",
         "js-cookie": "^2.2.1",
-        "next-myft-client": "^10.1.0",
+        "next-myft-client": "^10.3.0",
         "next-session-client": "^4.0.0",
         "superstore-sync": "^2.1.1"
       }
     },
     "@financial-times/n-newsletter-signup": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-newsletter-signup/-/n-newsletter-signup-9.2.0.tgz",
-      "integrity": "sha512-tiwua9ZT3HDm0wsuFp/rVv2yex1dIUkpeoo2bwWJ0u9lc52y782Rv/M0uIg2cWqsI6Vn6tKLSnEqadjZcVJkOQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-newsletter-signup/-/n-newsletter-signup-10.0.0.tgz",
+      "integrity": "sha512-/LY0kniuL1OzXMCDSVdc/e77JOzECkOmqWQDvc58SJ3yhO5dngnSj3PBjWEDRCHYIVH5amh2TWuWfOWCtcX6+g==",
       "requires": {
         "@financial-times/dotcom-server-handlebars": "3.0.0",
         "@financial-times/n-myft-ui": "^28.0.6",
@@ -27445,18 +27461,13 @@
             "react": "^16.12.0",
             "react-dom": "^16.12.0"
           }
-        },
-        "dateformat": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
-          "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
         }
       }
     },
     "@financial-times/n-notification": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-notification/-/n-notification-8.2.2.tgz",
-      "integrity": "sha512-PJrWD/YW/Hf7xqnoqALMMr/RDTy9fX0CG3k3ZHHyf/ihkrXMmjqZGvjw3tZqIJQhrqaTQ7A3By0heKSRTga8JQ==",
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-notification/-/n-notification-8.2.4.tgz",
+      "integrity": "sha512-QNBpjKai1lvNnh8mAYoYmE0cDaB9h6qILMG/WWh482Q6SQMdoiuFMbxHlICItX8PxBo+i0zyEMhnRIc8hn3QcQ==",
       "peer": true,
       "requires": {}
     },
@@ -27528,9 +27539,9 @@
       "requires": {}
     },
     "@financial-times/o-colors": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-colors/-/o-colors-6.4.2.tgz",
-      "integrity": "sha512-M9I652qnTL6nDARt/3S2cbmJsiM34ag+1kfHtt37xMf2ZsXA/M7c0s+fYO2UWJ308+eWSa1aA8P5Dl13jndmzQ==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-colors/-/o-colors-6.5.1.tgz",
+      "integrity": "sha512-pNa6G3+CdJ1kiVtW1RAoETn5nwGQ/33ddRxgW7dYO5lZC+KU3MTWKO9PxpR9WU34FXvH+WKsFNmEhdUW9/3pqA==",
       "peer": true,
       "requires": {}
     },
@@ -27558,11 +27569,14 @@
       "requires": {}
     },
     "@financial-times/o-forms": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-forms/-/o-forms-9.4.0.tgz",
-      "integrity": "sha512-35aUkEhC4La3wABkqB4QNZwctR+UrFyU0SoSFZH3EA9pCxp20x9CYpYdr8E2106ArK0Uab+jJc8snAw5ukew+A==",
+      "version": "9.9.2",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-forms/-/o-forms-9.9.2.tgz",
+      "integrity": "sha512-pv2B5y1/uDkCIipvqRsPqgsqgJdrtRkKVepd3zu6BQ2n8a6NAPWx1X73qIlvFJRF+OUOOKq+HZ/ODr3NrUqABw==",
       "peer": true,
-      "requires": {}
+      "requires": {
+        "@types/lodash.uniqueid": "^4.0.7",
+        "lodash.uniqueid": "^4.0.1"
+      }
     },
     "@financial-times/o-grid": {
       "version": "6.1.5",
@@ -27586,23 +27600,23 @@
       "requires": {}
     },
     "@financial-times/o-loading": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-loading/-/o-loading-5.2.1.tgz",
-      "integrity": "sha512-63wLZuONKI1tygnq3xUxm1zYsLllBFhyQ+0jK2fnPuUTwzgquHZaO9ncdnsjqs1s2WF3rToZK8dpGlPRsjWgBw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-loading/-/o-loading-5.2.2.tgz",
+      "integrity": "sha512-nlYdz9FFNpHCJLYup1xT5JDs7zvF8RY/AoI5TgzJDGj1VN8EgxUXD3p2J3fb4JgqYEKRVR5iTi9zAo7xR7IpMg==",
       "peer": true,
       "requires": {}
     },
     "@financial-times/o-normalise": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-normalise/-/o-normalise-3.2.2.tgz",
-      "integrity": "sha512-w7eYm2EB4Wf4cY5IJ/B55xst32mFQIW41f+HZpfykJEvI0ohBM2ghfaLu+JpJdaAv8kRaV8245FdDcngDst3wA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-normalise/-/o-normalise-3.3.1.tgz",
+      "integrity": "sha512-ha33JQBrquklTYb+swGV7FsNfFzP4eDfl2PscV5PruC8fjKkXZWtXuiSXU3m1xIU8+qTb4UjR0q2WEG3fUluhw==",
       "peer": true,
       "requires": {}
     },
     "@financial-times/o-overlay": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-overlay/-/o-overlay-4.2.4.tgz",
-      "integrity": "sha512-4n4Bp7UqJYjmZTW5gzPnxvyU1pIB5+eK2FUimtxCgcDAt19b6u6zuFaZp3kumLyGNj5Q+qT0GIotLTAaKEVciA==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-overlay/-/o-overlay-4.2.8.tgz",
+      "integrity": "sha512-W9FHsCmLtYXAeMIYDKuE3WQ/5g0wId/6pXgby1j3Yl5q6MUax9SBNgLZ7+AVwN3RpkZRh2O8eTq4cbRI4Iy8Fg==",
       "peer": true,
       "requires": {
         "focusable": "^2.3.0",
@@ -27617,20 +27631,22 @@
       "requires": {}
     },
     "@financial-times/o-tooltip": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-tooltip/-/o-tooltip-5.2.4.tgz",
-      "integrity": "sha512-GXC320/zwTNvacG4PCHSwGBPb+3eWMw7pePUAw41iJ70Wjwy+H9aGbbQikWOiBCiSb6BohwImWOJ6RR0g1dReg==",
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-tooltip/-/o-tooltip-5.2.6.tgz",
+      "integrity": "sha512-9qPtucThIi0k9d17i9AQdw36WvFPqeypq9Ajdmki0+43TRK884Ap9LSFoj5nxT5NVR2BpDm+HghrHLYF5iRPLA==",
       "peer": true,
       "requires": {
         "ftdomdelegate": "^4.0.6"
       }
     },
     "@financial-times/o-topper": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-topper/-/o-topper-5.2.3.tgz",
-      "integrity": "sha512-4CoeEp5nG7ecmZuJMr7DlEs0w5mPS3jikHxOlVZqMP18qWlwXC6BgbPz1ZslxBt/+SnJmHlNN2VIQevPQLNtEQ==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-topper/-/o-topper-5.8.0.tgz",
+      "integrity": "sha512-CDmgoU+91ved0G9883akDDnFUaQyjM/3lpX4Hq8TTDT4wOS2mwxXXP5F9NvhSER9oXb3brmJp8w5tdi3RdyWhw==",
       "peer": true,
-      "requires": {}
+      "requires": {
+        "@financial-times/n-map-content-to-topper": "^3.2.0"
+      }
     },
     "@financial-times/o-typography": {
       "version": "7.3.2",
@@ -27642,9 +27658,9 @@
       }
     },
     "@financial-times/o-utils": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-utils/-/o-utils-2.1.1.tgz",
-      "integrity": "sha512-kZQfGjVI0A8axO3aPs8AIGStxG+jGX0FKZgjBTQAx+4Dud6vloVGJpSix+/Q7ym5rewjhDLsFVECM18Lvswbhw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-utils/-/o-utils-2.2.0.tgz",
+      "integrity": "sha512-fCm8428H6GOpNhpwNXDKCe5Gx9GPyrwgFg26UsAfVCVmyjOMFCp2TxJECP6Y+NaXJqx6ZYU4lhARxSiL2HO+5A==",
       "peer": true
     },
     "@financial-times/o-viewport": {
@@ -28857,6 +28873,21 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true
+    },
+    "@types/lodash": {
+      "version": "4.14.194",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.194.tgz",
+      "integrity": "sha512-r22s9tAS7imvBt2lyHC9B8AGwWnXaYb1tY09oyLkXDs4vArpYJzw09nj8MLx5VfciBPGIb+ZwG0ssYnEPJxn/g==",
+      "peer": true
+    },
+    "@types/lodash.uniqueid": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.uniqueid/-/lodash.uniqueid-4.0.7.tgz",
+      "integrity": "sha512-ipMGW5nR+DTR6U5O08k1Ufr1F9iH+F3p7bhdwsnq6V6nCn/HgMq22UalDq4n91+03+pHFKyeXV1Y7vdJrm7S4g==",
+      "peer": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
     },
     "@types/minimatch": {
       "version": "3.0.5"
@@ -31331,6 +31362,11 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.16.1.tgz",
       "integrity": "sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ=="
+    },
+    "dateformat": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
     },
     "debounce": {
       "version": "1.2.1",
@@ -38063,6 +38099,12 @@
       "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
       "dev": true
     },
+    "lodash.uniqueid": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.uniqueid/-/lodash.uniqueid-4.0.1.tgz",
+      "integrity": "sha512-GQQWaIeGlL6DIIr06kj1j6sSmBxyNMwI8kaX9aKpHR/XsMTiaXDVPNPAkiboOTK9OJpTJF/dXT3xYoFQnj386Q==",
+      "peer": true
+    },
     "log-update": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
@@ -38790,9 +38832,9 @@
       }
     },
     "next-myft-client": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/next-myft-client/-/next-myft-client-10.2.0.tgz",
-      "integrity": "sha512-tmCn7kleYGgSd+0kEhwUketVhm0c0Ci87yFODaGPESK7AT+RmTxdC9QA4oSl8Q9izAJz4dPAgC07fPcz2nr2aw==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/next-myft-client/-/next-myft-client-10.5.0.tgz",
+      "integrity": "sha512-IQqMJpc3wSzdkk2YOqPl6sJApcWzmOWBliNMZJLcSzgSqKEKVt0YCuQrpuRqKFGkqpduvZ47BL1g7lwXlUjD6g==",
       "requires": {
         "black-hole-stream": "0.0.1",
         "fetchres": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@financial-times/dotcom-server-handlebars": "^7.0.0",
     "@financial-times/ft-date-format": "^1.0.0",
     "@financial-times/n-eventpromo": "^10.0.1",
-    "@financial-times/n-newsletter-signup": "^9.2.0",
+    "@financial-times/n-newsletter-signup": "^10.0.0",
     "@financial-times/x-engine": "^1.0.2",
     "handlebars-loader": "^1.7.0",
     "js-cookie": "^2.2.0",


### PR DESCRIPTION
bumps n-newsletter-signup to [v10.0.0](https://github.com/Financial-Times/n-newsletter-signup/releases/tag/v10.0.0)

This version of n-newsletter-signup has been migrated from n-gage to [Toolkit](https://github.com/Financial-Times/dotcom-tool-kit). This should cause no breaking changes to functionality and only changes the workflow of the CI, tests and local demo build for n-newsletter-signup. However, it was released as a Major change due to the significance of this.