### PR TITLE
Support n-ui-foundations v10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,7 @@
       },
       "peerDependencies": {
         "@financial-times/o-labels": "^6.2.2",
-        "n-ui-foundations": "^9.0.0"
+        "n-ui-foundations": "^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/@actions/exec": {

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
   },
   "peerDependencies": {
     "@financial-times/o-labels": "^6.2.2",
-    "n-ui-foundations": "^9.0.0"
+    "n-ui-foundations": "^9.0.0 || ^10.0.0"
   },
   "x-dash": {
     "engine": {


### PR DESCRIPTION
A small PR to update to n-ui-foundations-v10.

This allows this module to be used with either v9 or v10 of this library.
