### PR TITLE
updated version of n-eventpromo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@financial-times/dotcom-server-handlebars": "^7.0.0",
         "@financial-times/ft-date-format": "^1.0.0",
-        "@financial-times/n-eventpromo": "^10.0.5",
+        "@financial-times/n-eventpromo": "^10.0.6",
         "@financial-times/n-newsletter-signup": "^10.0.0",
         "@financial-times/x-engine": "^1.0.2",
         "handlebars-loader": "^1.7.0",
@@ -2919,9 +2919,9 @@
       }
     },
     "node_modules/@financial-times/n-eventpromo": {
-      "version": "10.0.5",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-eventpromo/-/n-eventpromo-10.0.5.tgz",
-      "integrity": "sha512-hfH+u//soZ4UrGlGT5vShhYNh6isAMaSr3abN4L/zGd28wxL5r4ehJ4V2+ftSXXs8CsrAAjg9Q3a9LTVtsST0w==",
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-eventpromo/-/n-eventpromo-10.0.6.tgz",
+      "integrity": "sha512-PfizJvhzCW8UHq67A9z+1VvQPi4LatXoC4GVVsAWcKayB+UkZw63A3RexbvlNxAaFtlE0Bx2040GoJFl7YuRaA==",
       "dependencies": {
         "@financial-times/x-engine": "^1.0.0-beta.5"
       },
@@ -27696,9 +27696,9 @@
       "requires": {}
     },
     "@financial-times/n-eventpromo": {
-      "version": "10.0.5",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-eventpromo/-/n-eventpromo-10.0.5.tgz",
-      "integrity": "sha512-hfH+u//soZ4UrGlGT5vShhYNh6isAMaSr3abN4L/zGd28wxL5r4ehJ4V2+ftSXXs8CsrAAjg9Q3a9LTVtsST0w==",
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-eventpromo/-/n-eventpromo-10.0.6.tgz",
+      "integrity": "sha512-PfizJvhzCW8UHq67A9z+1VvQPi4LatXoC4GVVsAWcKayB+UkZw63A3RexbvlNxAaFtlE0Bx2040GoJFl7YuRaA==",
       "requires": {
         "@financial-times/x-engine": "^1.0.0-beta.5"
       }

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
   "dependencies": {
     "@financial-times/dotcom-server-handlebars": "^7.0.0",
     "@financial-times/ft-date-format": "^1.0.0",
-    "@financial-times/n-eventpromo": "^10.0.5",
+    "@financial-times/n-eventpromo": "^10.0.6",
     "@financial-times/n-newsletter-signup": "^10.0.0",
     "@financial-times/x-engine": "^1.0.2",
     "handlebars-loader": "^1.7.0",


### PR DESCRIPTION
### What
Updated version of n-eventpromo that contains a small change in the margin bottom of the button under the event promo component [PR](https://github.com/Financial-Times/n-eventpromo/pull/112)