### PR TITLE
updated version of n-eventpromo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@financial-times/dotcom-server-handlebars": "^7.0.0",
         "@financial-times/ft-date-format": "^1.0.0",
-        "@financial-times/n-eventpromo": "^10.0.6",
+        "@financial-times/n-eventpromo": "^10.0.7",
         "@financial-times/n-newsletter-signup": "^10.0.0",
         "@financial-times/x-engine": "^1.0.2",
         "handlebars-loader": "^1.7.0",
@@ -2919,9 +2919,9 @@
       }
     },
     "node_modules/@financial-times/n-eventpromo": {
-      "version": "10.0.6",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-eventpromo/-/n-eventpromo-10.0.6.tgz",
-      "integrity": "sha512-PfizJvhzCW8UHq67A9z+1VvQPi4LatXoC4GVVsAWcKayB+UkZw63A3RexbvlNxAaFtlE0Bx2040GoJFl7YuRaA==",
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-eventpromo/-/n-eventpromo-10.0.7.tgz",
+      "integrity": "sha512-KOA5d0469y7uCKVHNroF4r/DL/kYRzk3RTinWXORyssY1o7ntFnfAppcDmrFTxbgAkC1xXiAxWWedtCAwuTN3g==",
       "dependencies": {
         "@financial-times/x-engine": "^1.0.0-beta.5"
       },
@@ -27696,9 +27696,9 @@
       "requires": {}
     },
     "@financial-times/n-eventpromo": {
-      "version": "10.0.6",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-eventpromo/-/n-eventpromo-10.0.6.tgz",
-      "integrity": "sha512-PfizJvhzCW8UHq67A9z+1VvQPi4LatXoC4GVVsAWcKayB+UkZw63A3RexbvlNxAaFtlE0Bx2040GoJFl7YuRaA==",
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-eventpromo/-/n-eventpromo-10.0.7.tgz",
+      "integrity": "sha512-KOA5d0469y7uCKVHNroF4r/DL/kYRzk3RTinWXORyssY1o7ntFnfAppcDmrFTxbgAkC1xXiAxWWedtCAwuTN3g==",
       "requires": {
         "@financial-times/x-engine": "^1.0.0-beta.5"
       }

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
   "dependencies": {
     "@financial-times/dotcom-server-handlebars": "^7.0.0",
     "@financial-times/ft-date-format": "^1.0.0",
-    "@financial-times/n-eventpromo": "^10.0.6",
+    "@financial-times/n-eventpromo": "^10.0.7",
     "@financial-times/n-newsletter-signup": "^10.0.0",
     "@financial-times/x-engine": "^1.0.2",
     "handlebars-loader": "^1.7.0",


### PR DESCRIPTION
Issue: [HIVE-1840](https://financialtimes.atlassian.net/browse/HIVE-1840)

### What
Updated n-eventpromo to remove the explore all btn from the promo component

[HIVE-1840]: https://financialtimes.atlassian.net/browse/HIVE-1840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ