### PR TITLE
Set Content Discovery as Codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # See https://help.github.com/articles/about-codeowners/ for more information about this file.
 
-* @financial-times/storytelling
+* @Financial-Times/content-discovery


### PR DESCRIPTION
Reasons:

* Content Disco will do some refactoring to rationalise a tangle of dependencies that make it hard to test and deploy changes and also make it difficult to AB test features
* Most people seem to think Content Disco own this repo anyway
* It doesn't really align with much of Storytelling team's remit (except just that it's on the dotcom article page) and is somewhat closer to Content Disco's (not only a little bit 😆 )