### PR TITLE
Remove n-ui-foundations...

### DIFF
--- a/demos/demo.scss
+++ b/demos/demo.scss
@@ -1,4 +1,5 @@
 $system-code: 'n-magnet-demo';
+@import 'n-ui-foundations/main';
 @import '../main';
 
 html {

--- a/src/components/newsletter-signup/main.scss
+++ b/src/components/newsletter-signup/main.scss
@@ -1,7 +1,7 @@
+@import '@financial-times/o-normalise/main';
 @import '@financial-times/ft-concept-button/main';
 @import '@financial-times/o-labels/main';
 @import '@financial-times/o-buttons/main';
-@import 'n-ui-foundations/main';
 
 @include oLabels($opts: ('sizes': ('small'),
 	'states': ('content-premium'
@@ -85,7 +85,7 @@
 		color: oColorsByName('black-80');
 		margin: 0 0 0.5em 0;
 		max-width: 30em;
-	
+
 		@include oGridRespondTo($from: M) {
 			margin-bottom: 0;
 		}


### PR DESCRIPTION
The removes the normalise styles that are produce by n-ui-foundations from the CSS output by this component when it's included in next-article.

Instead we only need to include the o-normalise component to use one of its mixins.

n-ui-foundations is therefore only used in the demo app.